### PR TITLE
:bug: Set default auto-update to 0

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -6,7 +6,7 @@ download-path = downloads
 # 文件扩展名，支持 epub、txt、html，推荐 epub
 extname = epub
 # 启动时是否自动更新 (1 开，0 关)
-auto-update = 1
+auto-update = 0
 
 [crawl]
 # 爬取最小间隔 (毫秒)


### PR DESCRIPTION
auto-update may corrupt Scoop/Homebrew updates, set default value to 0.