### PR TITLE
:bug: fix watchConfig NoResourceException

### DIFF
--- a/src/main/java/com/pcdd/sonovel/Main.java
+++ b/src/main/java/com/pcdd/sonovel/Main.java
@@ -1,5 +1,6 @@
 package com.pcdd.sonovel;
 
+import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.io.resource.ResourceUtil;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.lang.ConsoleTable;
@@ -27,6 +28,7 @@ import org.jline.terminal.TerminalBuilder;
 import java.io.File;
 import java.util.List;
 import java.util.Scanner;
+import java.nio.file.Paths;
 
 import static org.fusesource.jansi.AnsiRenderer.render;
 
@@ -198,7 +200,13 @@ public class Main {
     }
 
     private static void watchConfig() {
-        String path = System.getProperty("user.dir") + File.separator + ConfigUtils.resolveConfigFileName();
+        String path;
+        String configFilePath = System.getProperty("config.file");
+        if (!FileUtil.exist(configFilePath)) {
+            path = System.getProperty("user.dir") + File.separator + ConfigUtils.resolveConfigFileName();
+        } else {
+            path = Paths.get(configFilePath).toAbsolutePath().toString();
+        }
         Setting setting = new Setting(path);
         // 监听配置文件
         setting.autoLoad(true, aBoolean -> {


### PR DESCRIPTION
This PR fixes the following issue:

```
Exception in thread "main" cn.hutool.core.io.resource.NoResourceException: File [/Users/ownia/codespace/so-novel/target/config.ini] not exist!
        at cn.hutool.core.io.resource.FileResource.getStream(FileResource.java:83)
        at cn.hutool.setting.SettingLoader.load(SettingLoader.java:77)
        at cn.hutool.setting.Setting.load(Setting.java:207)
        at cn.hutool.setting.Setting.init(Setting.java:195)
        at cn.hutool.setting.Setting.<init>(Setting.java:128)
        at cn.hutool.setting.Setting.<init>(Setting.java:116)
        at cn.hutool.setting.Setting.<init>(Setting.java:106)
        at com.pcdd.sonovel.Main.watchConfig(Main.java:202)
        at com.pcdd.sonovel.Main.main(Main.java:59)
```