### PR TITLE
feat(release-windows.sh): 添加run.bat脚本以支持UTF-8编码在Windows打包脚本中创建run.bat文件, 用于设置代码页为UTF-8并启动应用程序,确保在Windows环境下正确显示中文字符

### DIFF
--- a/bin/release-windows.sh
+++ b/bin/release-windows.sh
@@ -27,6 +27,12 @@ copy_files() {
     cp -r bundle/rules "$target_dir/"
     cp bundle/config.ini bundle/sonovel.l4j.ini bundle/readme.txt "$target_dir"
     cp "bundle/支持 & 赞助.png" "$target_dir"
+    # 创建chcp批处理脚本
+    cat > "$target_dir/run.bat" <<EOF
+@echo off
+chcp 65001 >nul
+start "" "sonovel.exe"
+EOF
 }
 
 extract_jre() {

--- a/bin/release-windows.sh
+++ b/bin/release-windows.sh
@@ -27,11 +27,10 @@ copy_files() {
     cp -r bundle/rules "$target_dir/"
     cp bundle/config.ini bundle/sonovel.l4j.ini bundle/readme.txt "$target_dir"
     cp "bundle/支持 & 赞助.png" "$target_dir"
-    # 创建chcp批处理脚本
     cat > "$target_dir/run.bat" <<EOF
 @echo off
 chcp 65001 >nul
-start "" "sonovel.exe"
+sonovel.exe
 EOF
 }
 


### PR DESCRIPTION
feat(release-windows.sh): 添加run.bat脚本以支持UTF-8编码在Windows打包脚本中创建run.bat文件, 用于设置代码页为UTF-8并启动应用程序,确保在Windows环境下正确显示中文字符

fix #63 

