### PR TITLE
Use strict equality in base64

### DIFF
--- a/src/main/resources/quanben5.js
+++ b/src/main/resources/quanben5.js
@@ -3,7 +3,7 @@ function base64(_str) {
   var encodechars = "";
   for (var i = 0; i < _str.length; i++) {
     var num0 = staticchars.indexOf(_str[i]);
-    if (num0 == -1) {
+    if (num0 === -1) {
       var code = _str[i]
     } else {
       var code = staticchars[(num0 + 3) % 62]


### PR DESCRIPTION
Was reading through src/main/resources/quanben5.js and the loose equality here can coerce values in ways that are hard to spot later. this patch tightens it to strict equality. Not sure if this is intentional, so feel free to ignore.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.