### PR TITLE
:recycle: Update homebrew installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ bash <(curl -sSL https://raw.githubusercontent.com/freeok/so-novel/main/bin/linu
 
 ```bash
 brew tap ownia/homebrew-ownia
+# https://docs.brew.sh/Tap-Trust#why-tap-trust-exists
+brew trust --formula ownia/homebrew-ownia/so-novel
 brew install so-novel
 ```
 


### PR DESCRIPTION
Since Homebrew 6.0.0, explicit trust is required for taps. Added the relevant installation steps.

Refer to: https://docs.brew.sh/Tap-Trust